### PR TITLE
Documentation handling

### DIFF
--- a/doc/02-entity-methods.md
+++ b/doc/02-entity-methods.md
@@ -290,6 +290,60 @@ private class PersonFilterProvider : FilterProvider
 }
 ```
 
+### The SQL IN clause limit
+
+Identity Manager enforces a limit on the length of SQL in clauses that are embedded in query strings. When calling the `ISqlFormatter`'s `InClause` function, an exception will be thrown if the list includes more than 1024 elements. This is because SQL Server will often fail to create execution plans when the list of the form `<column> in ( 'uid1', 'uid2', ...)` becomes very long.
+
+To work around this limit, the easiest option is to break up the query into partitions of sizes below 1024 elements. Depending on the context, this option may not always be available.
+
+In the context of an API method, the function might be used like this.
+
+``` csharp
+Method.Define("person")
+  .FromTable("Person")
+  .WithParameter("values", typeof(string), "Comma-separated values", isInQuery: true)
+  .EnableRead()
+  
+  .WithWhereClause(request =>
+  {
+    var values = request.Parameters.Get<string>("values").Split(',');
+    return request.Session.SqlFormatter().InClause("UID_Person", ValType.String, values);
+  })
+```
+
+However, the code above will fail with more than 1024 list elements.
+
+Instead, you can use an `ExpressionClause` which is not subject to the 1024 element limit.
+
+``` csharp
+Method.Define("person")
+  .FromTable("Person")
+  .WithParameter("values", typeof(string), "Comma-separated values"))
+  .EnableRead()
+
+  .WithClause(request => new ExpressionClause(ExpressionClauseType.In,
+       new ColumnReference("Person", "UID_Person"),
+       new FixValue
+       {
+          Value = request.Parameters.Get<string>("values").Split(',')
+       }))
+```
+
+The following example shows how to pass a list of values as a parameter. This solution adds two clauses to the query:
+
+- a parameter clause that defines a SQL query parameter,
+- and a string clause that reads this parameter using the `QBM_FCVStringToList` function.
+
+``` csharp
+public static void BuildInClause(IEnumerable<string> values, Query query, string selectionColumn)
+{
+    var parameterName = "p" + SecureRandom.Int();
+    query.AddClause(new QueryParameter(parameterName, ValType.String, string.Join("|", values)));
+
+    query.AddClause(new WhereClause(selectionColumn + " in (select parametervalue from QBM_FCVStringToList(@" + parameterName + ", '|', 0, 0))";
+}
+```
+
 ## Grouping
 
 To enable the grouping API, ensure that the `EnableGroupingApi` and `EnableDataModelApi` properties are set to `true`.

--- a/doc/05-composition-api-plugins.md
+++ b/doc/05-composition-api-plugins.md
@@ -480,3 +480,42 @@ public class SamplePasswordItemProvider : IPasswordItemProvider
 }
 ```
 
+## Ownership providers
+
+The Composition API uses plugins to assign ownership to business objects. For example, this is used to determine if a user is allowed to request history information through the history API for an object.
+
+Integrating custom data types in the history API will require an implementation of the `IOwnershipInfoProvider` interface like shown in the following example.
+
+``` csharp
+public class CustomOwnershipInfoProvider : IOwnershipInfoProvider
+{
+    public IReadOnlyList<IOwnershipInfo> BuildOwnershipInfos(IResolve resolver)
+    {
+        return new[] { new CustomOwnershipInfo() };
+    }
+}
+
+public class CustomOwnershipInfo : IOwnershipInfo
+{
+    public string GetWhereClause()
+    {
+        // Objects matching this condition will show up under "My responsibilities"
+        return "1=0"; 
+    }
+
+    public async Task<bool> IsOwnerAsync(ISession session, IEntity entity, CancellationToken ct)
+    {
+        // TODO: insert code to determine ownership for this object under
+        // the supplied session context.
+        return true;
+    }
+
+    // Data table name of the custom object type.
+    public string TableName => "CCCTableName";
+
+    // List of program functions that grant administrative access
+    // to objects of this type.
+    public IReadOnlyCollection<string> FeatureNamesAdmin { get; }
+        = new[] { "Portal_UI_MyCustomAdminFeature" };
+}
+```


### PR DESCRIPTION
This pull request adds documentation updates to clarify advanced usage and extension points for the Identity Manager and Composition API. The main changes include guidance on handling SQL IN clause limits and instructions for implementing custom ownership providers for extending the history API.

**SQL IN clause handling:**

* Added documentation describing the 1024-element limit on SQL IN clauses when using `ISqlFormatter.InClause`, including workarounds such as partitioning queries and using `ExpressionClause` to bypass the limit. Example code snippets are provided to illustrate both approaches.

**Ownership provider integration:**

* Added a section explaining how to implement the `IOwnershipInfoProvider` interface for custom business objects, enabling integration with the history API and ownership determination logic. Includes a sample implementation for reference.